### PR TITLE
Add autogenerated .htaccess to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ## SnippetVamp
 #################
 
+.htaccess
 config.dat
 last_version.txt
 log.txt


### PR DESCRIPTION
.htaccess is automatically generated by SnippetVamp and not version controlled. Better to include it in the .gitignore so that the git repo stays "clean" by not showing "untracked" files.
